### PR TITLE
Problem in parsing k and K

### DIFF
--- a/maw.cc
+++ b/maw.cc
@@ -60,6 +60,8 @@ int main(int argc, char **argv)
 
 		k       = sw . k;
 		K       = sw . K;
+		//fprintf ( stderr, "k is %d and  K is %d \n", k,K );
+                if (K<=k) {usage(); return 1;};
 		r       = sw . r;
 
                 input_filename          = sw . input_filename;


### PR DESCRIPTION
No error is generated when user mistakenly input "-k" twice instead of "-k" and "-K" (see below). 
The program silently attributes the value of the second "-k" to both k and K.

The proposed modification is a quick and dirty way of avoiding the bug. 
A better way to solve this would be for the function decode_switches() to return an error.  Changing from -k / -K to, for example, -kmin / -kmax could also circumvent the problem. 

Problem demo : 
# ./maw -a DNA -i U00096.fna -o test.fna -k 2 -K  10

k is 2 and  K is 10
# ./maw -a DNA -i U00096.fna -o test.fna -k 2 -k 10

k is 10 and  K is 10
