### PR TITLE
Allow input via stdin and output via stdout

### DIFF
--- a/functions.cc
+++ b/functions.cc
@@ -582,7 +582,11 @@ unsigned int GetMaws( unsigned char * seq, unsigned char * seq_id, INT * SA, INT
 	}
 	StackDispose(&lifo_lcp);
 
-	if ( ! ( out_fd = fopen ( out_file, "a") ) )
+	if ( strncmp (out_file, "-", 1) == 0)
+	{
+		out_fd = stdout;
+	}
+	else if ( ! ( out_fd = fopen ( out_file, "a") ) )
 	{
 		fprintf ( stderr, " Error: Cannot open file %s!\n", out_file );
 		return ( 1 );
@@ -645,7 +649,7 @@ unsigned int GetMaws( unsigned char * seq, unsigned char * seq_id, INT * SA, INT
 
 	fprintf( out_fd, "\n" );
 
-	if ( fclose ( out_fd ) )
+	if ( strncmp (out_file, "-", 1) == 1 && fclose ( out_fd ) )
 	{
 		fprintf( stderr, " Error: file close error!\n");
 		return ( 1 );

--- a/maw.cc
+++ b/maw.cc
@@ -70,7 +70,10 @@ int main(int argc, char **argv)
 	double start = gettime();
 
 	/* Read the (Multi)FASTA file in memory */
-	if ( ! ( in_fd = fopen ( input_filename, "r") ) )
+	if ( strncmp (input_filename, "-", 1) == 0) {
+		in_fd = stdin;
+	}
+	else if ( ! ( in_fd = fopen ( input_filename, "r") ) )
 	{
 		fprintf ( stderr, " Error: Cannot open file %s!\n", input_filename );
 		return ( 1 );


### PR DESCRIPTION
Hi,
We're using `maw` to search for similar copies of scans of 16th century printed music: https://f-tempo.org/
[Searching Page-Images of Early Music Scanned with OMR: A Scalable Solution Using Minimal Absent Words](https://zenodo.org/record/1492391)

We're calling the `maw` binary on demand from our webserver to create words, and so found that it was helpful to be able to pass data in and read data directly from stdin/stdout instead of first writing it to a temporary file. Perhaps this would also be useful for others.